### PR TITLE
HPC Days: Added talks schedule 

### DIFF
--- a/docs/hpcdays/index.md
+++ b/docs/hpcdays/index.md
@@ -8,11 +8,10 @@ Please consult the [HPC Days 2025 landing page](https://www.durham.ac.uk/researc
 
 ```{toctree}
 :hidden:
-cfp
+talks
 tutorials
 keynotes
 workshops
-talks
 contribute
 ```
 

--- a/docs/hpcdays/index.md
+++ b/docs/hpcdays/index.md
@@ -12,6 +12,7 @@ cfp
 tutorials
 keynotes
 workshops
+talks
 contribute
 ```
 

--- a/docs/hpcdays/index.md
+++ b/docs/hpcdays/index.md
@@ -43,7 +43,7 @@ contribute
 <tr>
   <td> 9:45-10:30 </td>
   <td>  </td>
-  <td> Workshop: <a href="workshops.html#WHPC">Women in HPC (WHPC) </a> <br /><br /> Talks </td>
+  <td> Workshop: <a href="workshops.html#WHPC">Women in HPC (WHPC) </a> <br /><br /> <a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#wednesday-4-june-2025-0945-to-1030">Talks</a> </td>
   <td> Workshop: <a href="workshops.html#eCSE">eCSE Session</a><br/><br/>Workshop: Particle Physics </td>
   <td> Workshop: <a href="workshops.html#NumericalRelativity">Numerical Relativity</a><br/><br/>
        Workshop: <a href="workshops.html#Benchmarking">Benchmarking</a> </td>
@@ -56,7 +56,7 @@ contribute
   <td> 11:00-12:30 </td>
   <td> Tutorial: FTorch </td>
   <td> Tutorial: <a href="tutorials.html#lustre-user-group-darshan-profiling-on-lustre">Lustre</a> <br /> <br /> Tutorial: AMD GPUs </td>
-  <td> Meeting: DRI HPC Lab (internal)<br/><br /> Workshop: <a href="workshops.html#Weather">HPC in Weather & Climate Research</a> <br/><br/> Talks</td>
+  <td> Meeting: DRI HPC Lab (internal)<br/><br /> Workshop: <a href="workshops.html#Weather">HPC in Weather & Climate Research</a> <br/><br/> <a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#wednesday-4-june-2025-1100-to-1230">Talks</a></td>
   <td> Workshop: <a href="workshops.html#eCSE">eCSE Session</a> <br/><br/>UKRI DRI </td>
   <td> Workshop: <a href="workshops.html#NumericalRelativity">Numerical Relativity</a> <br/><br/>Workshop: WHPC</td>
 </tr> 
@@ -68,7 +68,7 @@ contribute
   <td> 13:30-15:00 </td>
   <td> Tutorial: SmartSim </td>
   <td> Tutorial: SYCL <br /> <br /> Workshop: <a href="workshops.html#DiRACRSEs"> DiRAC RSEs </a> </td>
-  <td> Keynote: t.b.c. <br /><br /> Talks </td>
+  <td> Keynote: t.b.c. <br /><br /> <a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#wednesday-4-june-2025-1330-to-1500">Talks</a> </td>
   <td> Keynote: Digital Research Infrastructure <br /> (t.b.c.) <br /><br /> UKRI DRI</td>
   <td> Workshop: <a href="workshops.html#CoSeC">CoSeC</a> <br/><br/>Particle physics </td>
 </tr> 
@@ -86,7 +86,7 @@ contribute
 </tr>
 <tr>
   <td> 16:30-18:00 </td>
-  <td> Tutorial: SYCL <br /><br />  Workshop: DiRAC RSEs (internal) <br/><br/>Talks</td>
+  <td> Tutorial: SYCL <br /><br />  Workshop: DiRAC RSEs (internal) <br/><br/><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#tuesday-3-june-2025-1630-to-1650">Talks</a></td>
   <td>Sponsors lightning talks and panel</td>
   <td>Workshop: <a href="workshops.html#Bencharking">Benchmarking</a><br /><br />HPC RSE SIG meetup</td>
 </tr>

--- a/docs/hpcdays/talks.md
+++ b/docs/hpcdays/talks.md
@@ -21,21 +21,21 @@
 <td>16:50 - 17:10</td>
 <td>The HPC Hardware Lab at Durham University</td>
 <td>Alastair Basden</td>
-<td></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
 </tr>
 
 <tr>
 <td>17:10 - 17:30</td>
 <td>Commissioning Aire, a new HPC system at The University of Leeds</td>
 <td>Andrew Harvie</td>
-<td></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#commissioning-aire-a-new-hpc-system-at-the-university-of-leeds">details</a></td>
 </tr>
 
 <tr>
 <td>17:30 - 17:50</td>
 <td>Delivering Training with a mini HPC built from Raspberry Pis</td>
 <td>Jannetta Steyn</td>
-<td></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#delivering-training-with-a-mini-hpc-built-from-raspberry-pis">details</a></td>
 </tr>
 
 </table>
@@ -43,14 +43,17 @@
 ## Abstracts
 ### Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC
 **Who:** Richard Gilham, Bristol Centre for Supercomputing 
+
 **Abstract:** Isambard-AI and Isambard 3 offer a unique opportunity to rethink how we build supercomputers, from the data centre to the User Experience. The rapid adoption of AI, and indeed simulation HPC, across traditional and new research sectors has resulted in new communities of users to emerge with distinct requirements and skillsets. After introducing the Isambard supercomputers, this talk will explore our approach to User Experience and how it acts as a useful lens for decision-making when creating and maintaining an HPC service.
 
 ### The HPC Hardware Lab at Durham University
 **Who:** Alastair Basden, Durham University
+
 **Abstract:** The Durham HPC Hardware Lab is hosted by the DiRAC COSMA HPC facility and provides UK researchers with access to cutting edge technologies and facilities, to allow testing of codes, software migration to new hardware, and study of new paradigms. This lab has grown in scope over the past few years, funded by ExCALIBUR H&ES, DiRAC, Durham and various UKRI grants. Of particular interest to many users is access to new GPU systems, novel networking topologies, composable infrastructure, and access to BlueField DPUs. In addition to compute hardware, the Hardware Lab includes data centre-scale technologies, such as solar power generation, immersion cooling and waste heat storage. This talk presents the Hardware Lab, including information about how it can be accessed.
 
 ### Commissioning Aire, a new HPC system at The University of Leeds
 **Who:** Andrew Harvie, University of Leeds
+
 **Abstract:** Since the end of 2024, the Research Computing Team at the University of Leeds have been working on bringing online our new HPC system, Aire, while at the same time decommissioning our previous systems, ARC3 and ARC4. Aire represents a significant improvement in capability over the previous systems, most notably with a 7-fold increase in the number of available GPUs, accounting for the rapidly increasing demand for GPU compute in AI/ML applications. Deciding on a specification for the new system – particularly regarding GPU capabilities – required careful balancing of expected current and future use cases with considerations of time pressure and market factors. On the new system, we also decided to move to a new scheduler (Slurm, from Grid Engine). With completely new hardware and software platforms, we were free to start afresh in defining usage/support policies, system configurations, and documentation.
 
 In this talk I will discuss how we are approaching the ongoing commissioning of the new system, including:
@@ -63,4 +66,5 @@ In this talk I will discuss how we are approaching the ongoing commissioning of 
 
 ### Delivering Training with a mini HPC built from Raspberry Pis
 **Who:** Jannetta Steyn, Newcastle University
+
 **Abstract:** Building an HPC with Raspberry Pis might sound like something entertaining that you should do on a Sunday afternoon during that "long dark tea-time of the soul" but, in actual fact, it is no menial task. In this presentation I'll walk the audience through the process of selecting hardware and software and the pitfalls in building a working mini HPC with single board computers such as the Raspberry Pi. I will finally talk a bit about practical applications of the mini-HPC, particularly as a training tool where students can get to grips with a real HPC system in a safe setting where the consequences of making mistakes are minimal.

--- a/docs/hpcdays/talks.md
+++ b/docs/hpcdays/talks.md
@@ -1,0 +1,45 @@
+# Talks schedule
+
+## Tuesday, 3 June 2025
+
+<table border="0">
+<tr>
+<td><b>Time</b></td>
+<td><b>Talk</b></td>
+<td><b>Who</b></td>
+<td><b>Details</b></td>
+</tr>
+  
+<tr>
+<td>16:30 - 16:50</td>
+<td>Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC</td>
+<td>Richard Gilham</td>
+<td></td>
+</tr>
+
+<tr>
+<td>16:50 - 17:10</td>
+<td>The HPC Hardware Lab at Durham University</td>
+<td>Alastair Basden</td>
+<td></td>
+</tr>
+
+<tr>
+<td>17:10 - 17:30</td>
+<td>Commissioning Aire, a new HPC system at The University of Leeds</td>
+<td>Andrew Harvie</td>
+<td></td>
+</tr>
+
+<tr>
+<td>17:30 - 17:50</td>
+<td>Delivering Training with a mini HPC built from Raspberry Pis</td>
+<td>Jannetta Steyn</td>
+<td></td>
+</tr>
+
+</table>
+
+## Abstracts
+### Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC
+**Who:** Richard Gilham, Bristol Centre for Supercomputing Isambard-AI and Isambard 3 offer a unique opportunity to rethink how we build supercomputers, from the data centre to the User Experience. The rapid adoption of AI, and indeed simulation HPC, across traditional and new research sectors has resulted in new communities of users to emerge with distinct requirements and skillsets. After introducing the Isambard supercomputers, this talk will explore our approach to User Experience and how it acts as a useful lens for decision-making when creating and maintaining an HPC service.

--- a/docs/hpcdays/talks.md
+++ b/docs/hpcdays/talks.md
@@ -7,14 +7,14 @@
 <td><b>Time</b></td>
 <td><b>Talk</b></td>
 <td><b>Who</b></td>
-<td><b>Details</b></td>
+<td></td>
 </tr>
   
 <tr>
 <td>16:30 - 16:50</td>
 <td>Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC</td>
 <td>Richard Gilham</td>
-<td>[here](https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc)</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
 </tr>
 
 <tr>
@@ -44,3 +44,23 @@
 ### Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC
 **Who:** Richard Gilham, Bristol Centre for Supercomputing 
 **Abstract:** Isambard-AI and Isambard 3 offer a unique opportunity to rethink how we build supercomputers, from the data centre to the User Experience. The rapid adoption of AI, and indeed simulation HPC, across traditional and new research sectors has resulted in new communities of users to emerge with distinct requirements and skillsets. After introducing the Isambard supercomputers, this talk will explore our approach to User Experience and how it acts as a useful lens for decision-making when creating and maintaining an HPC service.
+
+### The HPC Hardware Lab at Durham University
+**Who:** Alastair Basden, Durham University
+**Abstract:** The Durham HPC Hardware Lab is hosted by the DiRAC COSMA HPC facility and provides UK researchers with access to cutting edge technologies and facilities, to allow testing of codes, software migration to new hardware, and study of new paradigms. This lab has grown in scope over the past few years, funded by ExCALIBUR H&ES, DiRAC, Durham and various UKRI grants. Of particular interest to many users is access to new GPU systems, novel networking topologies, composable infrastructure, and access to BlueField DPUs. In addition to compute hardware, the Hardware Lab includes data centre-scale technologies, such as solar power generation, immersion cooling and waste heat storage. This talk presents the Hardware Lab, including information about how it can be accessed.
+
+### Commissioning Aire, a new HPC system at The University of Leeds
+**Who:** Andrew Harvie, University of Leeds
+**Abstract:** Since the end of 2024, the Research Computing Team at the University of Leeds have been working on bringing online our new HPC system, Aire, while at the same time decommissioning our previous systems, ARC3 and ARC4. Aire represents a significant improvement in capability over the previous systems, most notably with a 7-fold increase in the number of available GPUs, accounting for the rapidly increasing demand for GPU compute in AI/ML applications. Deciding on a specification for the new system – particularly regarding GPU capabilities – required careful balancing of expected current and future use cases with considerations of time pressure and market factors. On the new system, we also decided to move to a new scheduler (Slurm, from Grid Engine). With completely new hardware and software platforms, we were free to start afresh in defining usage/support policies, system configurations, and documentation.
+
+In this talk I will discuss how we are approaching the ongoing commissioning of the new system, including:
+ - Balancing supporting pre-existing workflows with the desire to keep a slim common software environment,
+ - Choosing GPUs; balancing cost and availability vs performance and FP64 support when deciding between L40S and H100 cards,
+ - Encouraging best practices from HPC users; balancing software engineering with social engineering for best security, reproducibility and system performance,
+ - Onboarding first test users; managing expectations and being useful to researchers while extracting useful testing information,
+ - How and when to write user documentation during active commissioning.
+ - Lessons learnt for (very near) future HPC systems. 
+
+### Delivering Training with a mini HPC built from Raspberry Pis
+**Who:** Jannetta Steyn, Newcastle University
+**Abstract:** Building an HPC with Raspberry Pis might sound like something entertaining that you should do on a Sunday afternoon during that "long dark tea-time of the soul" but, in actual fact, it is no menial task. In this presentation I'll walk the audience through the process of selecting hardware and software and the pitfalls in building a working mini HPC with single board computers such as the Raspberry Pi. I will finally talk a bit about practical applications of the mini-HPC, particularly as a training tool where students can get to grips with a real HPC system in a safe setting where the consequences of making mistakes are minimal.

--- a/docs/hpcdays/talks.md
+++ b/docs/hpcdays/talks.md
@@ -1,6 +1,6 @@
 # Talks schedule
 
-## Tuesday, 3 June 2025
+## Tuesday, 3 June 2025, 16:30 to 16:50
 
 <table border="0">
 <tr>
@@ -40,6 +40,116 @@
 
 </table>
 
+## Wednesday, 4 June 2025, 09:45 to 10:30
+
+<table border="0">
+<tr>
+<td><b>Time</b></td>
+<td><b>Talk</b></td>
+<td><b>Who</b></td>
+<td></td>
+</tr>
+  
+<tr>
+<td>9:45 - 10:05</td>
+<td>Benchmarking ML applications</td>
+<td>Adrian Jackson</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
+</tr>
+
+<tr>
+<td>10:05 - 10:25</td>
+<td>Understanding Embeddings in Machine Learning: A Business, Engineering, and Technical Overview</td>
+<td>Pahuldeep Singh Walia</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+</table>
+
+## Wednesday, 4 June 2025, 11:00 to 12:30
+
+<table border="0">
+<tr>
+<td><b>Time</b></td>
+<td><b>Talk</b></td>
+<td><b>Who</b></td>
+<td></td>
+</tr>
+  
+<tr>
+<td>11:00 - 11:20</td>
+<td>HPC waste heat storage: the ICHS project at Durham University</td>
+<td>Alastair Basden</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
+</tr>
+
+<tr>
+<td>11:20 - 11:40</td>
+<td>Advancing CATS, The Climate Aware Task Scheduler, for HPC and HTC application</td>
+<td>Sadie Bartholomew</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+
+<tr>
+<td>11:40 - 12:00</td>
+<td>AI for Green HPC: How Machine Learning is Transforming Energy Efficiency</td>
+<td>Fawada Qaiser</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+
+<tr>
+<td>12:00 - 12:20</td>
+<td>Driving energy efficiency of operation with wind turbing modelling</td>
+<td>Nick Brown</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+</table>
+
+## Wednesday, 4 June 2025, 13:30 to 15:00
+
+<table border="0">
+<tr>
+<td><b>Time</b></td>
+<td><b>Talk</b></td>
+<td><b>Who</b></td>
+<td></td>
+</tr>
+  
+<tr>
+<td>13:30 - 13:50</td>
+<td>Having it all: Can software be portable, performant and productive?</td>
+<td>Chris Maynard</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
+</tr>
+
+<tr>
+<td>13:50 - 14:10</td>
+<td>Scientific Computing with JAX: A Case Study Evaluating Gravitational Lensing Likelihood</td>
+<td>Kolen Cheung</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+
+<tr>
+<td>14:10 - 14:30</td>
+<td>Simulating Discrete-Event Systems on HPC: Sleptsov Net Case Study</td>
+<td>Dmitry Zaitsev</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+
+<tr>
+<td>14:30 - 14:50</td>
+<td>GPU offloads for gravity calculations in SWIFT cosmology code</td>
+<td>Sarah Johnson</td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+</tr>
+
+</table>
+
 ## Abstracts
 ### Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC
 **Who:** Richard Gilham, Bristol Centre for Supercomputing 
@@ -68,3 +178,67 @@ In this talk I will discuss how we are approaching the ongoing commissioning of 
 **Who:** Jannetta Steyn, Newcastle University
 
 **Abstract:** Building an HPC with Raspberry Pis might sound like something entertaining that you should do on a Sunday afternoon during that "long dark tea-time of the soul" but, in actual fact, it is no menial task. In this presentation I'll walk the audience through the process of selecting hardware and software and the pitfalls in building a working mini HPC with single board computers such as the Raspberry Pi. I will finally talk a bit about practical applications of the mini-HPC, particularly as a training tool where students can get to grips with a real HPC system in a safe setting where the consequences of making mistakes are minimal.
+
+### Benchmarking ML applications
+**Who:** Adrian Jackson, EPCC
+
+**Abstract:** TBC
+
+### Understanding Embeddings in Machine Learning: A Business, Engineering, and Technical Overview
+**Who:** Pahuldeep Singh Walia
+
+**Abstract:** TBC
+
+### HPC waste heat storage: the ICHS project at Durham University
+**Who:** Alastair Basden, Durham University
+
+**Abstract:** We present the ICHS project (Immersion Cooling and Heat Storage) at Durham University, researching into techniques to reduce the environmental impact of HPC. This project is two-fold: firstly we have a HPC immersion tank to explore techniques to maximise waste heat temperature increasing reusability, and secondly we are exploring the use of flooded mine workings beneath the data centre for inter-seasonal storage of data centre waste heat, allowing heat to be captured during summer months and reused for building heating during the winter. With HPC and AI consuming an ever increasing amount of electricity, making best use of the waste heat is critical.
+
+### Advancing CATS, The Climate Aware Task Scheduler, for HPC and HTC application
+**Who:** Sadie Bartholomew, NCAS
+
+**Abstract:** We 'all need HPC', therefore we all need to power HPC systems. But with significant environmental impact from the production of hardware and cooling alone, it is crucial to consider and try to minimise the greenhouse gas requirements from the compute itself in order to be sustainable. To this end, we present work to develop further the Python package CATS, the Climate-Aware Task Scheduler (https://github.com/GreenScheduler/cats), which schedules tasks to minimise the total estimated carbon intensity of the electricity grid for the job duration using real-time data from the UK's National Grid ESO API. While Version 1 of the tool, released last summer, was designed for use with the 'at' command hence targeted smaller-scale tasks on local machines, the upcoming Version 2 will integrate with Slurm for application in HPC and HTC. The aspiration is to soon work with systems administrators at volunteer centres to incorporate CATS Version 2 into key UK systems to provide users with the option to intelligently time shift their jobs through use of a 'green' queue or similar. We outline progress towards this goal.
+
+### AI for Green HPC: How Machine Learning is Transforming Energy Efficiency
+**Who:** Fawada Qaiser, Durham University
+
+**Abstract:** As High-Performance Computing (HPC) scales to meet increasing computational demands, energy efficiency has become a critical challenge, both for sustainability and operational costs. Traditional power management techniques, such as static power capping and uniform cooling strategies, often fail to adapt to dynamic workloads, leading to inefficiencies. This talk explores how Artificial Intelligence (AI) and Machine Learning (ML) are revolutionizing energy efficiency in HPC by enabling predictive modelling, reinforcement learning-based optimization, and adaptive workload scheduling.
+
+AI-driven predictive energy models leverage real-time telemetry and historical data to forecast power usage, allowing for proactive energy-saving strategies. Case studies from leading supercomputing facilities highlight how reinforcement learning and neural networks enhance power-aware job scheduling, cooling management, and dynamic power adjustments for CPUs, GPUs, and accelerators. Additionally, ML-driven auto-tuning techniques optimise the performance-energy trade-off in real time, balancing computational efficiency with power consumption.
+
+The session also addresses key research challenges, including the need for high-resolution power monitoring, algorithm scalability, and hardware-software co-design for energy-aware AIHPC integration. The talk provides insights into cutting-edge AI solutions that are driving energyefficient HPC operations, ultimately contributing to greener and more cost-effective computing infrastructures.
+
+### Driving energy efficiency of operation with wind turbing modelling
+**Who:** Nick Brown, EPCC
+
+**Abstract:** TBC
+
+### Having it all: Can software be portable, performant and productive?
+**Who:** Chris Maynard, Met Office
+
+**Abstract:** Weather and climate models simulate complex, multi-scale physics. They can deliver substantial value for society utilising their predictive power. However, it can take a decade or more to develop a new model. Moreover, computer architectures and the programming models used to develop the software have evolved on a much shorter time-scale and become more complex. How can large science applications achieve portability, performance and yet still allow developers to be productive? In this presentation the Domain Specific Language (DSL) approach being adopted by the Met Office in developing its next generation model, LFRic, will be discussed.
+
+A DSL has been co-designed with the development of the new dynamical core, the latter called Gung Ho. Moreover, a domain specific compiler, called PSyclone has been developed as part of the DSL approach. Distributed memory parallelism, expressed over MPI has been developed in the DSL from the start. The DSL approach will be described. This approach is now being extended. How directive based programming models are being used on modern CPUs and how they are being used to exploit the computational power of GPUs is described. The approach for the physical parameterisation schemes will be presented and how working with partners from UK universities and beyond is helping to accelerate progress discussed. Preliminary performance results will be presented. To conclude, the pros and cons of the DSL approach will be discussed as well how programming model development is influencing scientific model development.
+
+### Scientific Computing with JAX: A Case Study Evaluating Gravitational Lensing Likelihood
+**Who:** Chris Maynard, University of Exeter
+
+**Abstract:** JAX is a Python library that combines just-in-time (JIT) compilation with automatic differentiation, powered by XLA (Accelerated Linear Algebra compiler), to target multiple hardware architectures including CPU, GPU (NVIDIA, AMD, Intel, Apple), and Google TPU. While primarily designed for machine learning research, JAX presents compelling advantages for scientific computing in the HPC landscape.
+
+As HPC increasingly depends on heterogeneous accelerators, JAX’s “write once, deploy anywhere” approach enables scientific libraries to efficiently utilize diverse computing resources. Python programmers familiar with array programming and other JIT solutions like Numba can transition to JAX with minimal code changes, allowing straightforward adoption. Additionally, automatic differentiation provides gradient calculations for optimization problems with minimal developer effort — automatically generating derivatives that would be prohibitively complex to implement manually, while enabling optimization algorithms to converge more rapidly with gradient information.
+
+This presentation examines the adaptation of a likelihood function calculation from Numba to JAX in the context of gravitational lensing analysis of James Webb Space Telescope observations. The case study specifically addresses the convergence of AI/ML techniques with traditional scientific computing, highlighting performance gains, implementation challenges, and practical considerations when migrating existing scientific code to JAX’s programming model. We’ll discuss how JAX enables scalable processing across different HPC hardware resources while maintaining scientific accuracy and computational efficiency.
+
+### Simulating Discrete-Event Systems on HPC: Sleptsov Net Case Study
+**Who:** Dmitry Zaitsev, University of Derby
+
+**Abstract:** Discrete-event systems (DES) are essentially sequential in their behavior that represents an obstacle for fast simulating them on HPC involving mass-parallel processing facilities such as multicore CPUs or GPUs. We are absorbed in simulating behavior of Sleptsov nets, which are proven Turing-complete and are applied recently as a graphical language of concurrent programming in a wide range of domain. Placetransition nets introduced by Carl Petri fire a single transition at a step that makes HPC only applicable for parallel computing of the fireable transition set and for firing the chosen transition at a step. To speed-up the process on GPU, we use a matrix of threads to calculate the firing multiplicity of arcs, with reduction of minimum to compute the vector of firing multiplicity of transitions; then we use a vector of threads to fire a transition. Applying Sleptsov firing rule with a multiple firing of a transition at a step, we speed-up the process exponentially. We obtain the utmost performance, combining Sletpsov rule with Salwicki rule to fire the maximal multiset of fireable transitions at a step. Though, the maximal multiset choice is a rather hard task to be implemented at a step. We keep a good balance of the step computation complexity applying ad-hoc heuristics. A series of benchmarks obtained for CPUs and GPUs confirm robustness of the developed algorithms. For modern GPUs, we experienced considerable limitations of the global synchronization with regard to the grid size that requires using a few kernels to simulate a Sleptsov net step for big nets. The multiple firing of a transition (a multichannel transition), was re-invented after years under the name of “exhaustive use of rule” that allowed researchers to obtain exponential speed-up for spiking neural P systems, multiset rewriting systems, DNA computing, and other DESs. 
+
+### GPU offloads for gravity calculations in SWIFT cosmology code
+**Who:** Sarah Johnson, Durham University
+
+**Abstract:** To be compliant with modern heterogeneous HPC systems, large astronomy codes are needing to move towards GPU compatibility. SWIFT (SPH With Inter-dependent Fine-grained Tasking) is a versatile, open-source astronomy code used for a range of research areas in astronomy including galaxy formation, planetary impacts, and cosmology. A significant portion of SWIFT’s runtime is dedicated to gravity calculations. In gravity n-body codes, each particle (representing a celestial object) interacts with every other particle based on gravitational forces, making the calculations computationally intensive. However, the repetitive and non-interdependent nature of these n-body interactions makes them ideal candidates for GPU acceleration.
+
+In this work, we build on the existing SWIFT code by replacing specific CPU-based gravity calculation functions with new GPU kernels, minimizing disruption to the rest of the code while preserving the task-based parallelism. This creates a new hybrid C and CUDA version of the code which transfers gravity calculations to the GPU, freeing up the CPU to carry out the other tasks. Our GPU-accelerated gravity kernels achieve high accuracy, with less than 1% deviation from CPU results below the Nyquist frequency. Furthermore, the utilisation of GPUs allows for a redistribution of the gravity calculations making the results more accurate.
+
+Although we currently face a memory transfer bottleneck, optimization efforts using CUDA atomics and streams have shown promising improvements. Future work will focus on eliminating this bottleneck, further integrating GPU offloading into SWIFT’s task system, and leveraging additional GPU features to achieve an overall performance boost for the SWIFT code. 

--- a/docs/hpcdays/talks.md
+++ b/docs/hpcdays/talks.md
@@ -14,7 +14,7 @@
 <td>16:30 - 16:50</td>
 <td>Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC</td>
 <td>Richard Gilham</td>
-<td></td>
+<td>[here](https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc)</td>
 </tr>
 
 <tr>
@@ -42,4 +42,5 @@
 
 ## Abstracts
 ### Isambard-AI and Isambard 3: Democratising the User Experience for AI and simulation HPC
-**Who:** Richard Gilham, Bristol Centre for Supercomputing Isambard-AI and Isambard 3 offer a unique opportunity to rethink how we build supercomputers, from the data centre to the User Experience. The rapid adoption of AI, and indeed simulation HPC, across traditional and new research sectors has resulted in new communities of users to emerge with distinct requirements and skillsets. After introducing the Isambard supercomputers, this talk will explore our approach to User Experience and how it acts as a useful lens for decision-making when creating and maintaining an HPC service.
+**Who:** Richard Gilham, Bristol Centre for Supercomputing 
+**Abstract:** Isambard-AI and Isambard 3 offer a unique opportunity to rethink how we build supercomputers, from the data centre to the User Experience. The rapid adoption of AI, and indeed simulation HPC, across traditional and new research sectors has resulted in new communities of users to emerge with distinct requirements and skillsets. After introducing the Isambard supercomputers, this talk will explore our approach to User Experience and how it acts as a useful lens for decision-making when creating and maintaining an HPC service.

--- a/docs/hpcdays/talks.md
+++ b/docs/hpcdays/talks.md
@@ -54,14 +54,14 @@
 <td>9:45 - 10:05</td>
 <td>Benchmarking ML applications</td>
 <td>Adrian Jackson</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#benchmarking-ml-applications">details</a></td>
 </tr>
 
 <tr>
 <td>10:05 - 10:25</td>
 <td>Understanding Embeddings in Machine Learning: A Business, Engineering, and Technical Overview</td>
 <td>Pahuldeep Singh Walia</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#understanding-embeddings-in-machine-learning-a-business-engineering-and-technical-overview">details</a></td>
 </tr>
 
 </table>
@@ -80,14 +80,14 @@
 <td>11:00 - 11:20</td>
 <td>HPC waste heat storage: the ICHS project at Durham University</td>
 <td>Alastair Basden</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#hpc-waste-heat-storage-the-ichs-project-at-durham-university">details</a></td>
 </tr>
 
 <tr>
 <td>11:20 - 11:40</td>
 <td>Advancing CATS, The Climate Aware Task Scheduler, for HPC and HTC application</td>
 <td>Sadie Bartholomew</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#advancing-cats-the-climate-aware-task-scheduler-for-hpc-and-htc-application">details</a></td>
 </tr>
 
 
@@ -95,7 +95,7 @@
 <td>11:40 - 12:00</td>
 <td>AI for Green HPC: How Machine Learning is Transforming Energy Efficiency</td>
 <td>Fawada Qaiser</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#ai-for-green-hpc-how-machine-learning-is-transforming-energy-efficiency">details</a></td>
 </tr>
 
 
@@ -103,7 +103,7 @@
 <td>12:00 - 12:20</td>
 <td>Driving energy efficiency of operation with wind turbing modelling</td>
 <td>Nick Brown</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#driving-energy-efficiency-of-operation-with-wind-turbing-modelling">details</a></td>
 </tr>
 
 </table>
@@ -122,14 +122,14 @@
 <td>13:30 - 13:50</td>
 <td>Having it all: Can software be portable, performant and productive?</td>
 <td>Chris Maynard</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#isambard-ai-and-isambard-3-democratising-the-user-experience-for-ai-and-simulation-hpc">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#having-it-all-can-software-be-portable-performant-and-productive">details</a></td>
 </tr>
 
 <tr>
 <td>13:50 - 14:10</td>
 <td>Scientific Computing with JAX: A Case Study Evaluating Gravitational Lensing Likelihood</td>
 <td>Kolen Cheung</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#scientific-computing-with-jax-a-case-study-evaluating-gravitational-lensing-likelihood">details</a></td>
 </tr>
 
 
@@ -137,7 +137,7 @@
 <td>14:10 - 14:30</td>
 <td>Simulating Discrete-Event Systems on HPC: Sleptsov Net Case Study</td>
 <td>Dmitry Zaitsev</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#simulating-discrete-event-systems-on-hpc-sleptsov-net-case-study">details</a></td>
 </tr>
 
 
@@ -145,7 +145,7 @@
 <td>14:30 - 14:50</td>
 <td>GPU offloads for gravity calculations in SWIFT cosmology code</td>
 <td>Sarah Johnson</td>
-<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#the-hpc-hardware-lab-at-durham-university">details</a></td>
+<td><a href="https://durham.readthedocs.io/en/latest/hpcdays/talks.html#gpu-offloads-for-gravity-calculations-in-swift-cosmology-code">details</a></td>
 </tr>
 
 </table>


### PR DESCRIPTION
Added talks schedule to the programme and linked from the main page and menu to replace cfp