### PR TITLE
Use cosmadoc Harware Lab pages for Hardware Lab links

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Contents
    :caption: PROJECTS
 
    ichs/index
-   hardwarelab/index
+   HPC Hardware Lab @Durham <https://cosma.readthedocs.io/en/latest/hardwarelab.html>
    hpcdays/index
    netdrive/index
    datafed/index


### PR DESCRIPTION
- Redirects the Hardware Lab links to cosmadoc site.  Only merge after cosmadoc repo has been updated.

- Added a makefile for building the html site locally.  Feel free to ditch this if you don't want it in the repo.

Thanks